### PR TITLE
Adding FakeBoolean

### DIFF
--- a/src/main/kotlin/dev/fakek/FakeContext.kt
+++ b/src/main/kotlin/dev/fakek/FakeContext.kt
@@ -28,6 +28,7 @@ class FakeContext(private val faker: Faker = Faker.instance()) {
     private val fakerAddress by lazy { faker.address() }
     private val fakerAvatar by lazy { faker.avatar() }
     private val fakerBook by lazy { faker.book() }
+    private val fakerBoolean by lazy { faker.bool() }
     private val fakerColor by lazy { faker.color() }
     private val fakerInternet by lazy { faker.internet() }
     private val fakerName by lazy { faker.name() }
@@ -46,6 +47,11 @@ class FakeContext(private val faker: Faker = Faker.instance()) {
      * Provides a [FakeBook].
      */
     val fakeBook by lazy { FakeBook(fakerBook) }
+
+    /**
+     * Provides a [FakeBoolean].
+     */
+    val fakeBoolean by lazy { FakeBoolean(fakerBoolean) }
 
     /**
      * Provides a [FakeColor].

--- a/src/main/kotlin/dev/fakek/fakes/FakeBoolean.kt
+++ b/src/main/kotlin/dev/fakek/fakes/FakeBoolean.kt
@@ -1,0 +1,8 @@
+package dev.fakek.fakes
+
+/**
+ * FakeBoolean provides a fake boolean.
+ */
+data class FakeBoolean(val boolean: Boolean) {
+    constructor(fakerBoolean: FakerBoolean) : this(fakerBoolean.bool())
+}

--- a/src/main/kotlin/dev/fakek/fakes/FakerTypeAliases.kt
+++ b/src/main/kotlin/dev/fakek/fakes/FakerTypeAliases.kt
@@ -8,3 +8,4 @@ internal typealias FakerBook = Book
 internal typealias FakerColor = Color
 internal typealias FakerInternet = Internet
 internal typealias FakerName = Name
+internal typealias FakerBoolean = Bool

--- a/src/test/kotlin/dev/fakek/FakeContextTest.kt
+++ b/src/test/kotlin/dev/fakek/FakeContextTest.kt
@@ -73,4 +73,11 @@ internal class FakeContextTest {
 
         expectThat(fakeAvatar).hasSize(1)
     }
+
+    @Test
+    fun `given a FakeContext when fakeBoolean is accessed multiple times it should return the same value multiple times`() {
+        val fakeBoolean = createDistinctList { subject.fakeBoolean }
+
+        expectThat(fakeBoolean).hasSize(1)
+    }
 }

--- a/src/test/kotlin/dev/fakek/fakes/FakeBooleanTest.kt
+++ b/src/test/kotlin/dev/fakek/fakes/FakeBooleanTest.kt
@@ -1,0 +1,23 @@
+package dev.fakek.fakes
+
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import strikt.api.expectThat
+import strikt.assertions.isEqualTo
+
+internal class FakeBooleanTest {
+
+    private val trueBoolean by lazy { true }
+    private val fakerBoolean: FakerBoolean = mockk {
+        every { bool() } returns trueBoolean
+    }
+
+    @Test
+    fun `given a FakerBoolean when creating a FakeBoolean with param true then the correct boolean should be set`() {
+        val subject = FakeBoolean(fakerBoolean)
+
+        expectThat(subject.boolean).isEqualTo(trueBoolean)
+    }
+
+}


### PR DESCRIPTION
Closes #26 

## Description
Adds `fakeBoolean` to FakeContext to enable easier testing of true/false scenarios.

## Technical Details
- Changed `FakeContext` to add `fakeBoolean`.
- Added `FakeBoolean` class to provide the `fakeBoolean`.
- Changed `FakerTypeAliases` to add `FakerBoolean` alias.
- Changed `FakerContextTest` to add `fakeBoolean` test.
- Added `FakeBooleanTest` to test `FakeBoolean`.

## Code Samples
```kotlin
fun main() {
    val fakeBoolean: FakeBoolean(boolean=true)
    fakek { println("fakeBoolean: $fakeBoolean") }
}
```

Reviewers: @CodyEngel
