### PR TITLE
Enhancement / fake ancient

### DIFF
--- a/src/main/kotlin/dev/fakek/FakeContext.kt
+++ b/src/main/kotlin/dev/fakek/FakeContext.kt
@@ -26,6 +26,7 @@ fun <T> fakek(
  */
 class FakeContext(private val faker: Faker = Faker.instance()) {
     private val fakerAddress by lazy { faker.address() }
+    private val fakerAncient by lazy { faker.ancient() }
     private val fakerAvatar by lazy { faker.avatar() }
     private val fakerBook by lazy { faker.book() }
     private val fakerBoolean by lazy { faker.bool() }
@@ -37,6 +38,11 @@ class FakeContext(private val faker: Faker = Faker.instance()) {
      * Provides a [FakeAddress].
      */
     val fakeAddress by lazy { FakeAddress(fakerAddress) }
+
+    /**
+     * Provides a [FakeAncient].
+     */
+    val fakeAncient by lazy { FakeAncient(fakerAncient) }
 
     /**
      * Provides a [FakeAvatar].

--- a/src/main/kotlin/dev/fakek/fakes/FakeAncient.kt
+++ b/src/main/kotlin/dev/fakek/fakes/FakeAncient.kt
@@ -1,0 +1,23 @@
+package dev.fakek.fakes
+
+/**
+ * FakeAncient provides a fake ancient which includes a god, primordial, titan, and hero.
+ *
+ * @param god is a god name.
+ * @param primordial is a primordial name.
+ * @param titan is a titan name.
+ * @param hero is a hero name.
+ */
+data class FakeAncient(
+    val god: String,
+    val primordial: String,
+    val titan: String,
+    val hero: String
+) {
+    constructor(fakerAncient: FakerAncient) : this(
+        god = fakerAncient.god(),
+        primordial = fakerAncient.primordial(),
+        titan = fakerAncient.titan(),
+        hero = fakerAncient.hero()
+    )
+}

--- a/src/main/kotlin/dev/fakek/fakes/FakerTypeAliases.kt
+++ b/src/main/kotlin/dev/fakek/fakes/FakerTypeAliases.kt
@@ -9,3 +9,4 @@ internal typealias FakerColor = Color
 internal typealias FakerInternet = Internet
 internal typealias FakerName = Name
 internal typealias FakerBoolean = Bool
+internal typealias FakerAncient = Ancient

--- a/src/test/kotlin/dev/fakek/FakeContextTest.kt
+++ b/src/test/kotlin/dev/fakek/FakeContextTest.kt
@@ -80,4 +80,11 @@ internal class FakeContextTest {
 
         expectThat(fakeBoolean).hasSize(1)
     }
+
+    @Test
+    fun `given a FakeContext when fakeAncient is accessed multiple times it should return the same value multiple times`() {
+        val fakeAncient = createDistinctList { subject.fakeAncient }
+
+        expectThat(fakeAncient).hasSize(1)
+    }
 }

--- a/src/test/kotlin/dev/fakek/fakes/FakeAncientTest.kt
+++ b/src/test/kotlin/dev/fakek/fakes/FakeAncientTest.kt
@@ -1,0 +1,49 @@
+package dev.fakek.fakes
+
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import strikt.api.expectThat
+import strikt.assertions.isEqualTo
+
+internal class FakeAncientTest {
+
+    private val god by lazy { "God" }
+    private val primordial by lazy { "Primordial" }
+    private val titan by lazy { "Titan" }
+    private val hero by lazy { "Hero" }
+    private val fakerAncient: FakerAncient = mockk {
+        every { god() } returns god
+        every { primordial() } returns primordial
+        every { titan() } returns titan
+        every { hero() } returns hero
+    }
+
+    @Test
+    fun `given a FakerAncient when creating a FakeAncient then the correct god should be set`() {
+        val subject = FakeAncient(fakerAncient)
+
+        expectThat(subject.god).isEqualTo(god)
+    }
+
+    @Test
+    fun `given a FakerAncient when creating a FakeAncient then the correct primordial should be set`() {
+        val subject = FakeAncient(fakerAncient)
+
+        expectThat(subject.primordial).isEqualTo(primordial)
+    }
+
+    @Test
+    fun `given a FakerAncient when creating a FakeAncient then the correct titan should be set`() {
+        val subject = FakeAncient(fakerAncient)
+
+        expectThat(subject.titan).isEqualTo(titan)
+    }
+
+    @Test
+    fun `given a FakerAncient when creating a FakeAncient then the correct hero should be set`() {
+        val subject = FakeAncient(fakerAncient)
+
+        expectThat(subject.hero).isEqualTo(hero)
+    }
+}


### PR DESCRIPTION
Closes #11 

## Description
Creation of a wrapper of fake ancients.

## Technical Details
- Changed `FakeContext` to add `fakeAncient`.
- Added `FakeAncient` class to provide the `fakeAncient`.
- Changed `FakerTypeAliases` to add `FakerAncient` alias.
- Changed `FakerContextTest` to add `fakeAncient` test.
- Added `FakeAncientTest` to test `FakeAncient`.

## Code Samples
```kotlin
fun main() {
    val fakeAncient: FakeAncient(god="God", primordial="Primordial", titan="Titan", hero="Hero")
    fakek { println("Ancient: God - ${fakeAncient.god}, Primordial - ${fakeAncient.primordial}, Titan - ${fakeAncient.titan}, Hero - ${fakeAncient.hero}") }
}
```

Reviewers: @CodyEngel
