### PR TITLE
fake artist support

### DIFF
--- a/src/main/kotlin/dev/fakek/FakeContext.kt
+++ b/src/main/kotlin/dev/fakek/FakeContext.kt
@@ -27,6 +27,7 @@ fun <T> fakek(
 class FakeContext(private val faker: Faker = Faker.instance()) {
     private val fakerAddress by lazy { faker.address() }
     private val fakerAncient by lazy { faker.ancient() }
+    private val fakerArtist by lazy { faker.artist() }
     private val fakerAvatar by lazy { faker.avatar() }
     private val fakerBook by lazy { faker.book() }
     private val fakerBoolean by lazy { faker.bool() }
@@ -43,6 +44,11 @@ class FakeContext(private val faker: Faker = Faker.instance()) {
      * Provides a [FakeAncient].
      */
     val fakeAncient by lazy { FakeAncient(fakerAncient) }
+
+    /**
+     * Provides a [FakeArtist].
+     */
+    val fakeArtist by lazy { FakeArtist(fakerArtist) }
 
     /**
      * Provides a [FakeAvatar].

--- a/src/main/kotlin/dev/fakek/fakes/FakeArtist.kt
+++ b/src/main/kotlin/dev/fakek/fakes/FakeArtist.kt
@@ -1,0 +1,14 @@
+package dev.fakek.fakes
+
+/**
+ * FakeArtist provides a fake artist object that includes a single parameter - name.
+ *
+ * @param name is the name of the artist.
+ */
+data class FakeArtist(
+    val name: String
+) {
+    constructor(fakerArtist: FakerArtist) : this(
+        name = fakerArtist.name()
+    )
+}

--- a/src/main/kotlin/dev/fakek/fakes/FakerTypeAliases.kt
+++ b/src/main/kotlin/dev/fakek/fakes/FakerTypeAliases.kt
@@ -3,6 +3,7 @@ package dev.fakek.fakes
 import com.github.javafaker.*
 
 internal typealias FakerAddress = Address
+internal typealias FakerArtist = Artist
 internal typealias FakerAvatar = Avatar
 internal typealias FakerBook = Book
 internal typealias FakerColor = Color

--- a/src/test/kotlin/dev/fakek/FakeContextTest.kt
+++ b/src/test/kotlin/dev/fakek/FakeContextTest.kt
@@ -87,4 +87,11 @@ internal class FakeContextTest {
 
         expectThat(fakeAncient).hasSize(1)
     }
+
+    @Test
+    fun `given a FakeContext when fakeArtist is accessed multiple times it should return the same value multiple times`() {
+        val fakeArtist = createDistinctList { subject.fakeArtist }
+
+        expectThat(fakeArtist).hasSize(1)
+    }
 }

--- a/src/test/kotlin/dev/fakek/fakes/FakeArtistTest.kt
+++ b/src/test/kotlin/dev/fakek/fakes/FakeArtistTest.kt
@@ -1,0 +1,25 @@
+package dev.fakek.fakes
+
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import strikt.api.expectThat
+import strikt.assertions.isEqualTo
+
+class FakeArtistTest {
+
+    private val name = "John Lennon"
+
+    private val fakerArtist: FakerArtist = mockk {
+        every { name() } returns name
+    }
+
+    @Test
+    fun `given a FakerArtist when creating a FakeArtist then expect names to be equal`() {
+        val result = FakeArtist(name)
+        expectThat(result.name) {
+            get { isEqualTo(name) }
+        }
+    }
+
+}


### PR DESCRIPTION
Closes #14

## Description
Added support for artist, that includes a name.
## Technical Details

The implementation consists of following pieces:
  - FakeArtist.kt which represents the fake object of an artist with single param - name
  - FakeArtistTest.kt that includes a single unit test
  - several extensions in existing files including: FakeContext.kt, FakeContextTest.kt, FakerTypeAliases.kt  

## Code Samples
```kotlin
fun main() {
    val fakeArtist: FakeArtist(name = "John Doe")
    fakek { println("fakeArtist: $fakeArtist") }
}
```

Reviewers: @CodyEngel