### PR TITLE
Enhancement / FakeCommerce

### DIFF
--- a/src/main/kotlin/dev/fakek/FakeContext.kt
+++ b/src/main/kotlin/dev/fakek/FakeContext.kt
@@ -74,7 +74,7 @@ class FakeContext(private val faker: Faker = Faker.instance()) {
     /**
      * Provides a [FakeCommerce].
      */
-    val fakeCommerce by lazy { FakeCommerce(fakeAddress ,fakerCompany, fakeUrl) }
+    val fakeCommerce by lazy { FakeCommerce(fakeAddress, fakeCompany) }
 
     /**
      * Provides a [FakeCompany].

--- a/src/main/kotlin/dev/fakek/FakeContext.kt
+++ b/src/main/kotlin/dev/fakek/FakeContext.kt
@@ -72,6 +72,11 @@ class FakeContext(private val faker: Faker = Faker.instance()) {
     val fakeColor by lazy { FakeColor(fakerColor) }
 
     /**
+     * Provides a [FakeCommerce].
+     */
+    val fakeCommerce by lazy { FakeCommerce(fakeAddress ,fakerCompany, fakeUrl) }
+
+    /**
      * Provides a [FakeCompany].
      */
     val fakeCompany by lazy { FakeCompany(fakerCompany, fakeUrl) }

--- a/src/main/kotlin/dev/fakek/fakes/FakeCommerce.kt
+++ b/src/main/kotlin/dev/fakek/fakes/FakeCommerce.kt
@@ -5,4 +5,4 @@ import dev.fakek.interfaces.Company
 /**
  * FakeCommerce provides a commerce with random information.
  */
-class FakeCommerce(val address: FakeAddress, fakeCompany: FakeCompany) : Company by fakeCompany
+data class FakeCommerce(val address: FakeAddress, private val fakeCompany: FakeCompany) : Company by fakeCompany

--- a/src/main/kotlin/dev/fakek/fakes/FakeCommerce.kt
+++ b/src/main/kotlin/dev/fakek/fakes/FakeCommerce.kt
@@ -1,12 +1,8 @@
 package dev.fakek.fakes
 
+import dev.fakek.interfaces.Company
+
 /**
  * FakeCommerce provides a commerce with random information.
- *
- * @param address a instance of FakeAddress containing all info related to the fake address of the commerce.
  */
-class FakeCommerce(
-    val address: FakeAddress,
-    fakerCompany: FakerCompany,
-    fakeUrl: FakeUrl
-) : FakeCompany(fakerCompany, fakeUrl)
+class FakeCommerce(val address: FakeAddress, fakeCompany: FakeCompany) : Company by fakeCompany

--- a/src/main/kotlin/dev/fakek/fakes/FakeCommerce.kt
+++ b/src/main/kotlin/dev/fakek/fakes/FakeCommerce.kt
@@ -1,0 +1,12 @@
+package dev.fakek.fakes
+
+/**
+ * FakeCommerce provides a commerce with random information.
+ *
+ * @param address a instance of FakeAddress containing all info related to the fake address of the commerce.
+ */
+class FakeCommerce(
+    val address: FakeAddress,
+    fakerCompany: FakerCompany,
+    fakeUrl: FakeUrl
+) : FakeCompany(fakerCompany, fakeUrl)

--- a/src/main/kotlin/dev/fakek/fakes/FakeCompany.kt
+++ b/src/main/kotlin/dev/fakek/fakes/FakeCompany.kt
@@ -13,7 +13,7 @@ package dev.fakek.fakes
  * @param suffix
  * @param url random url of company website.
  */
-data class FakeCompany(
+open class FakeCompany(
     val bs: String,
     val buzzword: String,
     val catchPhrase: String,

--- a/src/main/kotlin/dev/fakek/fakes/FakeCompany.kt
+++ b/src/main/kotlin/dev/fakek/fakes/FakeCompany.kt
@@ -1,29 +1,21 @@
 package dev.fakek.fakes
 
+import dev.fakek.interfaces.Company
+
 /**
  * FakeCompany provides a company with random information.
- *
- * @param bs company corporate speak ex: "energistically mesh e-business opportunities".
- * @param buzzword
- * @param catchPhrase
- * @param industry
- * @param logo random url of the company logo.
- * @param name
- * @param profession
- * @param suffix
- * @param url random url of company website.
  */
-open class FakeCompany(
-    val bs: String,
-    val buzzword: String,
-    val catchPhrase: String,
-    val industry: String,
-    val logo: String,
-    val name: String,
-    val profession: String,
-    val suffix: String,
-    val url: String
-) {
+data class FakeCompany(
+    override val bs: String,
+    override val buzzword: String,
+    override val catchPhrase: String,
+    override val industry: String,
+    override val logo: String,
+    override val name: String,
+    override val profession: String,
+    override val suffix: String,
+    override val url: String
+) : Company {
     constructor(fakerCompany: FakerCompany, fakeUrl: FakeUrl) :
         this(
             fakerCompany.bs(),

--- a/src/main/kotlin/dev/fakek/interfaces/Company.kt
+++ b/src/main/kotlin/dev/fakek/interfaces/Company.kt
@@ -1,0 +1,26 @@
+package dev.fakek.interfaces
+
+/**
+ * Company provides a company with random information.
+ *
+ * @property bs company corporate speak ex: "energistically mesh e-business opportunities".
+ * @property buzzword
+ * @property catchPhrase
+ * @property industry
+ * @property logo random url of the company logo.
+ * @property name
+ * @property profession
+ * @property suffix
+ * @property url random url of company website.
+ */
+interface Company {
+    val bs: String
+    val buzzword: String
+    val catchPhrase: String
+    val industry: String
+    val logo: String
+    val name: String
+    val profession: String
+    val suffix: String
+    val url: String
+}

--- a/src/main/kotlin/dev/fakek/interfaces/Company.kt
+++ b/src/main/kotlin/dev/fakek/interfaces/Company.kt
@@ -1,26 +1,43 @@
 package dev.fakek.interfaces
 
 /**
- * Company provides a company with random information.
- *
- * @property bs company corporate speak ex: "energistically mesh e-business opportunities".
- * @property buzzword
- * @property catchPhrase
- * @property industry
- * @property logo random url of the company logo.
- * @property name
- * @property profession
- * @property suffix
- * @property url random url of company website.
+ * Company in an interface to implement fake companies.
  */
 interface Company {
+    /**
+     * @property bs company corporate speak ex: "energistically mesh e-business opportunities".
+     */
     val bs: String
+    /**
+     * @property buzzword
+     */
     val buzzword: String
+    /**
+     * @property catchPhrase
+     */
     val catchPhrase: String
+    /**
+     * @property industry
+     */
     val industry: String
+    /**
+     * @property logo random url of the company logo.
+     */
     val logo: String
+    /**
+     * @property name
+     */
     val name: String
+    /**
+     * @property profession
+     */
     val profession: String
+    /**
+     * @property suffix
+     */
     val suffix: String
+    /**
+     * @property url random url of company website.
+     */
     val url: String
 }

--- a/src/test/kotlin/dev/fakek/FakeContextTest.kt
+++ b/src/test/kotlin/dev/fakek/FakeContextTest.kt
@@ -88,6 +88,14 @@ internal class FakeContextTest {
         expectThat(fakeCompany).hasSize(1)
     }
 
+    @Test
+    fun `given a FakeContext when fakeCommerce is accessed multiple times it should return the same value multiple times`() {
+        val fakeCommerce = createDistinctList { subject.fakeCommerce }
+
+        expectThat(fakeCommerce).hasSize(1)
+    }
+
+    @Test
     fun `given a FakeContext when fakeAncient is accessed multiple times it should return the same value multiple times`() {
         val fakeAncient = createDistinctList { subject.fakeAncient }
 

--- a/src/test/kotlin/dev/fakek/fakes/FakeColorTest.kt
+++ b/src/test/kotlin/dev/fakek/fakes/FakeColorTest.kt
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test
 import strikt.api.expectThat
 import strikt.assertions.isEqualTo
 
-class FakeColorTest {
+internal class FakeColorTest {
 
     private val hexColor by lazy { "FF2D00" }
     private val hexColorWithHashSymbol by lazy { "#$hexColor" }

--- a/src/test/kotlin/dev/fakek/fakes/FakeCommerceTest.kt
+++ b/src/test/kotlin/dev/fakek/fakes/FakeCommerceTest.kt
@@ -1,0 +1,23 @@
+package dev.fakek.fakes
+
+import dev.fakek.fakes.utils.FakeCompanyBaseTest
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import strikt.api.expectThat
+import strikt.assertions.isA
+
+internal class FakeCommerceTest : FakeCompanyBaseTest() {
+
+    private val fakeAddress: FakeAddress = mockk()
+
+    @Test
+    fun `given a FakeCommerce it should be subtype of FakeCompany with a fake address`() {
+        val subject = FakeCommerce(fakeAddress, fakerCompany, fakeUrl)
+
+        expectThat(subject) {
+            isA<FakeCompany>()
+            get { address }.isA<FakeAddress>()
+        }
+    }
+
+}

--- a/src/test/kotlin/dev/fakek/fakes/FakeCommerceTest.kt
+++ b/src/test/kotlin/dev/fakek/fakes/FakeCommerceTest.kt
@@ -1,6 +1,7 @@
 package dev.fakek.fakes
 
 import dev.fakek.fakes.utils.FakeCompanyBaseTest
+import dev.fakek.interfaces.Company
 import io.mockk.mockk
 import org.junit.jupiter.api.Test
 import strikt.api.expectThat
@@ -8,14 +9,12 @@ import strikt.assertions.isA
 
 internal class FakeCommerceTest : FakeCompanyBaseTest() {
 
-    private val fakeAddress: FakeAddress = mockk()
-
     @Test
     fun `given a FakeCommerce it should be subtype of FakeCompany with a fake address`() {
-        val subject = FakeCommerce(fakeAddress, fakerCompany, fakeUrl)
+        val subject = FakeCommerce(mockk(), fakeCompany())
 
         expectThat(subject) {
-            isA<FakeCompany>()
+            isA<Company>()
             get { address }.isA<FakeAddress>()
         }
     }

--- a/src/test/kotlin/dev/fakek/fakes/FakeCompanyTest.kt
+++ b/src/test/kotlin/dev/fakek/fakes/FakeCompanyTest.kt
@@ -1,39 +1,13 @@
 package dev.fakek.fakes
 
+import dev.fakek.fakes.utils.FakeCompanyBaseTest
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.Test
-import strikt.api.expect
 import strikt.api.expectThat
 import strikt.assertions.isEqualTo
 
-class FakeCompanyTest {
-
-    private val bs = "fake everthing"
-    private val buzzword = "Fake-focused"
-    private val catchPhrase = "fake until you make it"
-    private val industry = "Fake Pproduct Services"
-    private val logo = "https://pigment.github.com/fake-logos/logos/medium/color/5.png"
-    private val name = "Faker-Corporate"
-    private val profession = "Faker"
-    private val suffix = "Group"
-
-    private val fakerCompany: FakerCompany = mockk {
-        every { bs() } returns bs
-        every { buzzword() } returns buzzword
-        every { catchPhrase() } returns catchPhrase
-        every { industry() } returns industry
-        every { logo() } returns logo
-        every { name() } returns name
-        every { profession() } returns profession
-        every { suffix() } returns suffix
-    }
-
-    private val url = "www.fake-url.com.fk"
-
-    private val fakerUrl = FakeUrl(url)
-
-    private fun fakeCompany() = FakeCompany(fakerCompany, fakerUrl)
+internal open class FakeCompanyTest : FakeCompanyBaseTest() {
 
     @Test
     fun `given a FakerCompany and FakerUrl when creating a FakeCompany then the correct data should be set`() {

--- a/src/test/kotlin/dev/fakek/fakes/utils/FakeCompanyBaseTest.kt
+++ b/src/test/kotlin/dev/fakek/fakes/utils/FakeCompanyBaseTest.kt
@@ -1,0 +1,35 @@
+package dev.fakek.fakes.utils
+
+import dev.fakek.fakes.FakeCompany
+import dev.fakek.fakes.FakeUrl
+import io.mockk.every
+import io.mockk.mockk
+import dev.fakek.fakes.FakerCompany
+
+internal open class FakeCompanyBaseTest {
+    protected val bs = "fake everthing"
+    protected val buzzword = "Fake-focused"
+    protected val catchPhrase = "fake until you make it"
+    protected val industry = "Fake Pproduct Services"
+    protected val logo = "https://pigment.github.com/fake-logos/logos/medium/color/5.png"
+    protected val name = "Faker-Corporate"
+    protected val profession = "Faker"
+    protected val suffix = "Group"
+
+    protected val fakerCompany: FakerCompany = mockk {
+        every { bs() } returns bs
+        every { buzzword() } returns buzzword
+        every { catchPhrase() } returns catchPhrase
+        every { industry() } returns industry
+        every { logo() } returns logo
+        every { name() } returns name
+        every { profession() } returns profession
+        every { suffix() } returns suffix
+    }
+
+    protected val url = "www.fake-url.com.fk"
+
+    protected val fakeUrl = FakeUrl(url)
+
+    protected fun fakeCompany() = FakeCompany(fakerCompany, fakeUrl)
+}


### PR DESCRIPTION
Closes #19

## Description
Creates a ```FakeCommerce``` that will works as a subtype of ```Company``` but, this class will fit things like ```address``` and ```products``` made by the ```company```

## Technical Details
change FakeCompany to sub type of Company
Add a new class FakeCommerce subtype of Company that delegate to FakeCompany
Add a utils folder in the tests with a FakeCompanyBaseTest with shared attributes and methods used for tests FakeCompay and its sub types (FakeCommerce)

## Code Samples
Please provide code samples for how these changes will be used by applications consuming this library. Here's an example:

```kotlin
fun main() {
    val fakeCommerce: FakeCommer()
    println("${fakeCommerce.name} is a commerce located in ${fakeCommerce.address.streetName}, ${fakeCommerce.address.city} that deals with ${fakeCommerce.profession}")
}
```

Reviewers: @CodyEngel
