### PR TITLE
Add fake cryptography

### DIFF
--- a/src/main/kotlin/dev/fakek/FakeContext.kt
+++ b/src/main/kotlin/dev/fakek/FakeContext.kt
@@ -35,9 +35,10 @@ class FakeContext(private val faker: Faker = Faker.instance()) {
     private val fakerCat by lazy { faker.cat() }
     private val fakerColor by lazy { faker.color() }
     private val fakerCompany by lazy { faker.company() }
+    private val fakerCrypto by lazy { faker.crypto() }
+    private val fakerDog by lazy { faker.dog() }
     private val fakerInternet by lazy { faker.internet() }
     private val fakerName by lazy { faker.name() }
-    private val fakerDog by lazy { faker.dog() }
 
     /**
      * Provides a [FakeAddress].
@@ -93,6 +94,11 @@ class FakeContext(private val faker: Faker = Faker.instance()) {
      * Provides a [FakeCreditCard].
      */
     val fakeCreditCard by lazy { FakeCreditCard.create() }
+
+    /**
+     * Provides a [fakeCrypto].
+     */
+    val fakeCrypto by lazy { FakeCrypto(fakerCrypto) }
 
     /**
      * Provides a [FakeEmailAddress] making use of [fakeName] to help generate parts of the email address.

--- a/src/main/kotlin/dev/fakek/fakes/FakeCrypto.kt
+++ b/src/main/kotlin/dev/fakek/fakes/FakeCrypto.kt
@@ -1,0 +1,24 @@
+package dev.fakek.fakes
+
+/**
+ * FakeCrypto provides a instance with fake generated cryptography.
+ *
+ * @param md5 message digested in a 128 bit value, see more in [here](https://en.wikipedia.org/wiki/MD5)
+ * @param sha1 a random value in cryptography in secure hash algorithm 1, see more in [here](https://en.wikipedia.org/wiki/SHA-1)
+ * @param sha256 a random value encrypted in secure hash algorithm 2 of 256 family, see more in [here](https://en.wikipedia.org/wiki/SHA-2)
+ * @param sha512 a random value encrypted in secure hash algorithm 2 of 512 family, see more in [here](https://en.wikipedia.org/wiki/SHA-2)
+ */
+data class FakeCrypto(
+    val md5: String,
+    val sha1: String,
+    val sha256: String,
+    val sha512: String
+) {
+    constructor(fakerCrypto: FakerCrypto):
+        this(
+            fakerCrypto.md5(),
+            fakerCrypto.sha1(),
+            fakerCrypto.sha256(),
+            fakerCrypto.sha512()
+        )
+}

--- a/src/main/kotlin/dev/fakek/fakes/FakeCrypto.kt
+++ b/src/main/kotlin/dev/fakek/fakes/FakeCrypto.kt
@@ -3,10 +3,14 @@ package dev.fakek.fakes
 /**
  * FakeCrypto provides a instance with fake generated cryptography.
  *
- * @param md5 message digested in a 128 bit value, see more in [here](https://en.wikipedia.org/wiki/MD5)
- * @param sha1 a random value in cryptography in secure hash algorithm 1, see more in [here](https://en.wikipedia.org/wiki/SHA-1)
- * @param sha256 a random value encrypted in secure hash algorithm 2 of 256 family, see more in [here](https://en.wikipedia.org/wiki/SHA-2)
- * @param sha512 a random value encrypted in secure hash algorithm 2 of 512 family, see more in [here](https://en.wikipedia.org/wiki/SHA-2)
+ * @param md5 message digested in a 128 bit value,
+ * see more in [here](https://en.wikipedia.org/wiki/MD5)
+ * @param sha1 a random value in cryptography in secure hash algorithm 1,
+ * see more in [here](https://en.wikipedia.org/wiki/SHA-1)
+ * @param sha256 a random value encrypted in secure hash algorithm 2 of 256 family,
+ * see more in [here](https://en.wikipedia.org/wiki/SHA-2)
+ * @param sha512 a random value encrypted in secure hash algorithm 2 of 512 family,
+ * see more in [here](https://en.wikipedia.org/wiki/SHA-2)
  */
 data class FakeCrypto(
     val md5: String,

--- a/src/main/kotlin/dev/fakek/fakes/FakeCrypto.kt
+++ b/src/main/kotlin/dev/fakek/fakes/FakeCrypto.kt
@@ -5,7 +5,7 @@ package dev.fakek.fakes
  *
  * @param md5 message digested in a 128 bit value,
  * see more in [here](https://en.wikipedia.org/wiki/MD5)
- * @param sha1 a random value in cryptography in secure hash algorithm 1,
+ * @param sha1 a random value encrypted in secure hash algorithm 1,
  * see more in [here](https://en.wikipedia.org/wiki/SHA-1)
  * @param sha256 a random value encrypted in secure hash algorithm 2 of 256 family,
  * see more in [here](https://en.wikipedia.org/wiki/SHA-2)

--- a/src/main/kotlin/dev/fakek/fakes/FakerTypeAliases.kt
+++ b/src/main/kotlin/dev/fakek/fakes/FakerTypeAliases.kt
@@ -3,15 +3,15 @@ package dev.fakek.fakes
 import com.github.javafaker.*
 
 internal typealias FakerAddress = Address
+internal typealias FakerAncient = Ancient
 internal typealias FakerArtist = Artist
 internal typealias FakerAvatar = Avatar
+internal typealias FakerBoolean = Bool
 internal typealias FakerBook = Book
 internal typealias FakerCat = Cat
 internal typealias FakerColor = Color
 internal typealias FakerCompany = Company
 internal typealias FakerCrypto = Crypto
+internal typealias FakerDog = Dog
 internal typealias FakerInternet = Internet
 internal typealias FakerName = Name
-internal typealias FakerBoolean = Bool
-internal typealias FakerAncient = Ancient
-internal typealias FakerDog = Dog

--- a/src/main/kotlin/dev/fakek/fakes/FakerTypeAliases.kt
+++ b/src/main/kotlin/dev/fakek/fakes/FakerTypeAliases.kt
@@ -9,6 +9,7 @@ internal typealias FakerBook = Book
 internal typealias FakerCat = Cat
 internal typealias FakerColor = Color
 internal typealias FakerCompany = Company
+internal typealias FakerCrypto = Crypto
 internal typealias FakerInternet = Internet
 internal typealias FakerName = Name
 internal typealias FakerBoolean = Bool

--- a/src/test/kotlin/dev/fakek/FakeContextTest.kt
+++ b/src/test/kotlin/dev/fakek/FakeContextTest.kt
@@ -103,6 +103,13 @@ internal class FakeContextTest {
     }
 
     @Test
+    fun `given a FakeContext when fakeCrypto is accessed multiple times it should return the same value multiple times`() {
+        val fakeCrypto = createDistinctList { subject.fakeCrypto }
+
+        expectThat(fakeCrypto).hasSize(1)
+    }
+
+    @Test
     fun `given a FakeContext when fakeAncient is accessed multiple times it should return the same value multiple times`() {
         val fakeAncient = createDistinctList { subject.fakeAncient }
 

--- a/src/test/kotlin/dev/fakek/fakes/FakeCryptoTest.kt
+++ b/src/test/kotlin/dev/fakek/fakes/FakeCryptoTest.kt
@@ -1,0 +1,37 @@
+package dev.fakek.fakes
+
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import strikt.api.expectThat
+import strikt.assertions.isEqualTo
+
+class FakeCryptoTest {
+
+    private val md5 by lazy { "2c259e9e1e874842c3269c1dfbb726f4" }
+    private val sha1 by lazy { "9a486863dcdab4d780259df861cb9909de195dc1" }
+    private val sha256 by lazy { "f33a0af645b1dc7ed00eb19c53d80e88af3eed4f264c28e6ac3278d7295d1900" }
+    private val sha512 by lazy { "24a58e877ed785d9f5a4cab29cfc0c7db2f0075a5fc4c7e3ef8ebbf99d97d8646524b73400061fc10c981c9cfc425a0c754979fbe713e768e3f010345246bf72" }
+
+    private val fakerCrypto by lazy {
+        mockk<FakerCrypto>()
+            .also {
+                every { it.md5() } returns md5
+                every { it.sha1() } returns sha1
+                every { it.sha256() } returns sha256
+                every { it.sha512() } returns sha512
+            }
+    }
+
+    @Test
+    fun `given a FakerCrypto when creating a FakeCrypto then the correct attribute values should be set`() {
+        val subject = FakeCrypto(fakerCrypto)
+
+        expectThat(subject) {
+            get { md5 }.isEqualTo(md5)
+            get { sha1 }.isEqualTo(sha1)
+            get { sha256 }.isEqualTo(sha256)
+            get { sha512 }.isEqualTo(sha512)
+        }
+    }
+}


### PR DESCRIPTION
Closes #38

## Description
Creates a fake cryptography class that provide random encrypted values
 
## Technical Details
Creates a fake ```cryptography``` class that wrap around faker to providing ```m5```, ```sha1``` and ```sha2``` (256 and 512) random values

## Code Samples

```kotlin
fun main() {
    val fakeCrypto =  fakek.crypto()
    val message = fakeCrypto.sha512()
    messageSender.prepareMessage(message).send()
    print("super secret message sent")
}
```

Reviewers: @CodyEngel
