### PR TITLE
Add fake aviation implementation

### DIFF
--- a/src/main/kotlin/dev/fakek/FakeContext.kt
+++ b/src/main/kotlin/dev/fakek/FakeContext.kt
@@ -30,6 +30,7 @@ class FakeContext(private val faker: Faker = Faker.instance()) {
     private val fakerAncient by lazy { faker.ancient() }
     private val fakerArtist by lazy { faker.artist() }
     private val fakerAvatar by lazy { faker.avatar() }
+    private val fakerAviation by lazy { faker.aviation() }
     private val fakerBeer by lazy { faker.beer() }
     private val fakerBook by lazy { faker.book() }
     private val fakerBoolean by lazy { faker.bool() }
@@ -61,6 +62,11 @@ class FakeContext(private val faker: Faker = Faker.instance()) {
      * Provides a [FakeAvatar].
      */
     val fakeAvatar by lazy { FakeAvatar(fakerAvatar) }
+
+    /**
+     * Provides a [FakeAviation].
+     */
+    val fakeAviation by lazy { FakeAviation(fakerAviation) }
 
     /**
      * Provides a [FakeBeer].

--- a/src/main/kotlin/dev/fakek/fakes/FakeAviation.kt
+++ b/src/main/kotlin/dev/fakek/fakes/FakeAviation.kt
@@ -1,0 +1,21 @@
+package dev.fakek.fakes
+
+/**
+ * FakeAviation provides a fake aviation info.
+ *
+ * @param METAR [weather report](https://en.wikipedia.org/wiki/METAR)
+ * @param aircraft aircraft model
+ * @param airport airport [ICAO code](https://en.wikipedia.org/wiki/International_Civil_Aviation_Organization)
+ */
+data class FakeAviation(
+    @Suppress("ConstructorParameterNaming")
+    val METAR: String,
+    val aircraft: String,
+    val airport: String
+) {
+    constructor(fakerAviation: FakerAviation) : this(
+        fakerAviation.METAR(),
+        fakerAviation.aircraft(),
+        fakerAviation.airport()
+    )
+}

--- a/src/main/kotlin/dev/fakek/fakes/FakerTypeAliases.kt
+++ b/src/main/kotlin/dev/fakek/fakes/FakerTypeAliases.kt
@@ -6,6 +6,7 @@ internal typealias FakerAddress = Address
 internal typealias FakerAncient = Ancient
 internal typealias FakerArtist = Artist
 internal typealias FakerAvatar = Avatar
+internal typealias FakerAviation = Aviation
 internal typealias FakerBeer = Beer
 internal typealias FakerBoolean = Bool
 internal typealias FakerBook = Book

--- a/src/test/kotlin/dev/fakek/FakeContextTest.kt
+++ b/src/test/kotlin/dev/fakek/FakeContextTest.kt
@@ -82,6 +82,13 @@ internal class FakeContextTest {
     }
 
     @Test
+    fun `given a FakeContext when fakeAviation is accessed multiple times it should return the same value multiple times`() {
+        val fakeAviation = createDistinctList { subject.fakeAviation }
+
+        expectThat(fakeAviation).hasSize(1)
+    }
+
+    @Test
     fun `given a FakeContext when fakeBoolean is accessed multiple times it should return the same value multiple times`() {
         val fakeBoolean = createDistinctList { subject.fakeBoolean }
 

--- a/src/test/kotlin/dev/fakek/fakes/FakeAviationTest.kt
+++ b/src/test/kotlin/dev/fakek/fakes/FakeAviationTest.kt
@@ -1,0 +1,33 @@
+package dev.fakek.fakes
+
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import strikt.api.expectThat
+import strikt.assertions.isEqualTo
+
+internal class FakeAviationTest {
+
+    private val METAR by lazy { "KTVL 021553Z 02012KT 10SM SKC 15/05 A3000" }
+    private val aircraft by lazy { "An-2" }
+    private val airport by lazy { "AGAF." }
+
+    private val fakerAviation: FakerAviation = mockk {
+        every { METAR() } returns METAR
+        every { aircraft() } returns aircraft
+        every { airport() } returns airport
+    }
+
+    private fun fakeAviation() = FakeAviation(fakerAviation)
+
+    @Test
+    fun `given a FakerAviation when creating a FakeAviation then the correct attributes should be set`() {
+        val subject = fakeAviation()
+
+        expectThat(subject) {
+            get { METAR } isEqualTo(METAR)
+            get { aircraft } isEqualTo(aircraft)
+            get { airport } isEqualTo(airport)
+        }
+    }
+}


### PR DESCRIPTION
Closes #35 

## Description
Add a fake aviation info: aircraft model, airport code and METAR (weather conditions)

## Technical Details
Add a new class called FakeAviation that wrapper FakerAviation in order to provide its attributes

## Code Samples
Please provide code samples for how these changes will be used by applications consuming this library. Here's an example:

```kotlin
fun main() {
    val aviation = fakek.fakeAviation
    val model = aviation.aircraft
    val destiny = aviation.airport
    val weather = aviation.METAR 
    println("The plane with model, $destiny, is about to get to the airport $destiny, it may suffer some problems given the wheather condition that is, according with the tower, $weather")
}
```

Reviewers: @CodyEngel
